### PR TITLE
Fix for MetaMask no longer injecting web3

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"@trendmicro/react-sidenav": "^0.4.5",
 		"@truffle/hdwallet-provider": "1.0.18",
 		"@zxing/library": "^0.15.2",
-		"axios": "^0.19.0",
+		"axios": ">=0.21.1",
 		"drizzle": "^1.4.0",
 		"drizzle-react": "^1.3.0",
 		"ethereumjs-tx": "^2.1.1",

--- a/src/components/TokenBalances.jsx
+++ b/src/components/TokenBalances.jsx
@@ -84,6 +84,9 @@ function TokenBalances(props, context) {
 						})}
 					{getTokenAddressesSortedByBalance().map((tokenAddr, index) => {
 						let token = props.fin4Tokens[tokenAddr];
+						if (!token) {
+							return;
+						}
 						return (
 							<TableRow
 								key={'balance_' + index}

--- a/src/middleware/ContractEventHandler.js
+++ b/src/middleware/ContractEventHandler.js
@@ -87,6 +87,9 @@ const contractEventHandlers = {
 		}
 		let quantity = new BN(claim.quantity).toNumber();
 		let token = store.getState().fin4Store.fin4Tokens[claim.tokenAddr];
+		if (!token) {
+			return;
+		}
 		let verifierStatusesObj = {};
 		for (let i = 0; i < claim.requiredVerifierTypes.length; i++) {
 			verifierStatusesObj[claim.requiredVerifierTypes[i]] = {
@@ -137,6 +140,9 @@ const contractEventHandlers = {
 			balance: Number(claim.newBalance)
 		});
 		let token = store.getState().fin4Store.fin4Tokens[claim.tokenAddr];
+		if (!token) {
+			return;
+		}
 		return (
 			<Trans
 				i18nKey="notification.claim-approved"
@@ -157,12 +163,18 @@ const contractEventHandlers = {
 			id: id
 		});
 		let token = store.getState().fin4Store.fin4Tokens[claim.tokenAddr];
+		if (!token) {
+			return;
+		}
 		return <Trans i18nKey="notification.claim-rejected" values={{ name: token.name }} />;
 	},
 	UpdatedTotalSupply: values => {
 		let tokenAddr = values.tokenAddr;
 		let totalSupply = new BN(values.totalSupply).toNumber();
 		let token = store.getState().fin4Store.fin4Tokens[tokenAddr];
+		if (!token) {
+			return;
+		}
 		if (token.totalSupply === totalSupply) {
 			// block duplicate events, not sure if this can happen, but just to be sure
 			return;

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -4,7 +4,7 @@ import drizzleOptions from '../config/drizzle-config';
 import { toast } from 'react-toastify';
 import update from 'react-addons-update';
 import Cookies from 'js-cookie';
-import { doCallback, txErrorAugmentation } from '../components/utils';
+import { doCallback, txErrorAugmentation, WeiToETH } from '../components/utils';
 const BN = require('bignumber.js');
 
 const contractEventNotifier = store => next => action => {
@@ -65,7 +65,7 @@ function fin4StoreReducer(state = initialState, action) {
 			return {
 				...state,
 				defaultAccount: action.account,
-				usersEthBalance: window.web3 ? window.web3.toDecimal(window.web3.fromWei(action.accountBalance, 'ether')) : 0
+				usersEthBalance: WeiToETH(action.accountBalance)
 			};
 		case 'DRIZZLE_INITIALIZED':
 			return {


### PR DESCRIPTION
The MetaMask Firefox extension is a few versions ahead of the Chrome extension. The Firefox one doesn't work anymore due to the breaking changes in MetaMask regarding no longer injecting web3, more info [here](https://docs.metamask.io/guide/provider-migration.html#replacing-window-web3). When trying to fix the issue, it seems there was very little to do actually to my surprise. Mainly a few `undefined`-guards and one location that I should have used `Utils` for anyways. 